### PR TITLE
Add css file with design tokens

### DIFF
--- a/styles/common.css
+++ b/styles/common.css
@@ -1,18 +1,24 @@
 /* This file contains design tokens used in core Gleam projects */
 :root {
+  /* Grays */
   --col-black: #000000;
   --col-chinese-black: #151515;
   --col-eerie-black: #1e1e1e;
+  --col-gunmetal: #292d3e;
   --col-dark-charcoal: #2f2f2f;
   --col-english-violet: #584355;
+  --col-purple-navy: #51597b;
   --col-gray: #7e818b;
   --col-dark-vanilla: #cac0a9;
-  --col-baby-powder: #fefefc;
   --col-cosmic-latte: #fffbe8;
+  --col-baby-powder: #fefefc;
+  /* Colors */
   --col-faff-pink: #ffaff3;
-  --col-waterspout: #a6f0fc;
-  --col-deep-saffron: #ff9d35;
   --col-pastel-red: #ff6262;
+  --col-deep-saffron: #ff9d35;
   --col-caramel: #ffd596;
+  --col-khaki: #b1a894;
+  --col-bone: #e3d8be;
   --col-menthol: #c8ffa7;
+  --col-waterspout: #a6f0fc;
 }

--- a/styles/common.css
+++ b/styles/common.css
@@ -27,6 +27,7 @@
 
   /* Semantic colors */
   --brand-primary: var(--col-magenta-300);
+  --brand-primary-dim: var(--col-magenta-800);
   --brand-success: var(--col-green-200);
   --brand-warning: var(--col-yellow-300);
   --brand-error: var(--col-red-400);

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,6 +1,6 @@
 /* This file contains design tokens used in core Gleam projects */
 :root {
-  /* Grays */
+  /* Greys */
   --col-black: #000000;
   --col-neutral-950: #151515;
   --col-neutral-900: #1e1e1e;
@@ -11,6 +11,7 @@
   --col-sepia-300: #e3d8be;
   --col-sepia-100: #fffbe8;
   --col-sepia-050: #fefefc;
+
   /* Colors */
   --col-magenta-800: #584355;
   --col-magenta-300: #ffaff3;
@@ -21,4 +22,18 @@
   --col-yellow-300: #ffd596;
   --col-orange-400: #ff9d35;
   --col-red-400: #ff6262;
+
+  /* Semantic colors */
+  --brand-primary: var(--col-magenta-300);
+
+  /* Light theme */
+  --light-theme-background: var(--col-sepia-050);
+  --light-theme-text: var(--col-black);
+  --light-theme-text-secondary: var(--col-neutral-800);
+
+  /* Dark theme */
+  --dark-theme-background: var(--col-azure-800);
+  --dark-theme-background-alt: var(--col-neutral-800);
+  --dark-theme-text: var(--col-sepia-300);
+  --dark-theme-text-secondary: var(--col-sepia-450);
 }

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,0 +1,18 @@
+/* This file contains design tokens used in core Gleam projects */
+:root {
+  --col-black: #000000;
+  --col-chinese-black: #151515;
+  --col-eerie-black: #1e1e1e;
+  --col-dark-charcoal: #2f2f2f;
+  --col-english-violet: #584355;
+  --col-gray: #7e818b;
+  --col-dark-vanilla: #cac0a9;
+  --col-baby-powder: #fefefc;
+  --col-cosmic-latte: #fffbe8;
+  --col-faff-pink: #ffaff3;
+  --col-waterspout: #a6f0fc;
+  --col-deep-saffron: #ff9d35;
+  --col-pastel-red: #ff6262;
+  --col-caramel: #ffd596;
+  --col-menthol: #c8ffa7;
+}

--- a/styles/common.css
+++ b/styles/common.css
@@ -2,23 +2,23 @@
 :root {
   /* Grays */
   --col-black: #000000;
-  --col-chinese-black: #151515;
-  --col-eerie-black: #1e1e1e;
-  --col-gunmetal: #292d3e;
-  --col-dark-charcoal: #2f2f2f;
-  --col-english-violet: #584355;
-  --col-purple-navy: #51597b;
-  --col-gray: #7e818b;
-  --col-dark-vanilla: #cac0a9;
-  --col-cosmic-latte: #fffbe8;
-  --col-baby-powder: #fefefc;
+  --col-neutral-950: #151515;
+  --col-neutral-900: #1e1e1e;
+  --col-neutral-800: #2f2f2f;
+  --col-zinc-500: #7e818b;
+  --col-sepia-450: #b1a894;
+  --col-sepia-400: #cac0a9;
+  --col-sepia-300: #e3d8be;
+  --col-sepia-100: #fffbe8;
+  --col-sepia-050: #fefefc;
   /* Colors */
-  --col-faff-pink: #ffaff3;
-  --col-pastel-red: #ff6262;
-  --col-deep-saffron: #ff9d35;
-  --col-caramel: #ffd596;
-  --col-khaki: #b1a894;
-  --col-bone: #e3d8be;
-  --col-menthol: #c8ffa7;
-  --col-waterspout: #a6f0fc;
+  --col-magenta-800: #584355;
+  --col-magenta-300: #ffaff3;
+  --col-azure-800: #292d3e;
+  --col-azure-600: #51597b;
+  --col-cyan-200: #a6f0fc;
+  --col-green-200: #c8ffa7;
+  --col-yellow-300: #ffd596;
+  --col-orange-400: #ff9d35;
+  --col-red-400: #ff6262;
 }

--- a/styles/common.css
+++ b/styles/common.css
@@ -2,10 +2,10 @@
 :root {
   /* Greys */
   --col-black: #000000;
-  --col-neutral-950: #151515;
-  --col-neutral-900: #1e1e1e;
-  --col-neutral-800: #2f2f2f;
-  --col-neutral-100: #f5f5f5;
+  --col-grey-950: #151515;
+  --col-grey-900: #1e1e1e;
+  --col-grey-800: #2f2f2f;
+  --col-grey-100: #f5f5f5;
   --col-azure-900: #202431;
   --col-azure-800: #292d3e;
   --col-azure-600: #51597b;
@@ -17,33 +17,33 @@
   --col-sepia-050: #fefefc;
 
   /* Colors */
-  --col-magenta-800: #584355;
-  --col-magenta-300: #ffaff3;
-  --col-cyan-200: #a6f0fc;
-  --col-green-200: #c8ffa7;
-  --col-yellow-300: #ffd596;
-  --col-orange-400: #ff9d35;
-  --col-red-400: #ff6262;
+  --col-faff-pink-800: #584355;
+  --col-faff-pink-300: #ffaff3;
+  --col-boi-blue-200: #a6f0fc;
+  --col-menthol-200: #c8ffa7;
+  --col-caramel-300: #ffd596;
+  --col-deep-saffron-400: #ff9d35;
+  --col-tomato-400: #ff6262;
 
   /* Semantic colors */
-  --brand-primary: var(--col-magenta-300);
-  --brand-primary-dim: var(--col-magenta-800);
-  --brand-success: var(--col-green-200);
-  --brand-warning: var(--col-yellow-300);
-  --brand-error: var(--col-red-400);
+  --brand-primary: var(--col-faff-pink-300);
+  --brand-primary-dim: var(--col-faff-pink-800);
+  --brand-success: var(--col-menthol-200);
+  --brand-warning: var(--col-caramel-300);
+  --brand-error: var(--col-tomato-400);
 
   /* Light theme */
   --light-theme-background: var(--col-sepia-050);
-  --light-theme-background-dim: var(--col-neutral-100);
+  --light-theme-background-dim: var(--col-grey-100);
   --light-theme-text: var(--col-black);
-  --light-theme-text-secondary: var(--col-neutral-800);
+  --light-theme-text-secondary: var(--col-grey-800);
   --light-theme-code: var(--col-black);
 
   /* Dark theme */
   --dark-theme-background: var(--col-azure-800);
   --dark-theme-background-dim: var(--col-azure-900);
-  --dark-theme-background-alt: var(--col-neutral-800);
+  --dark-theme-background-alt: var(--col-grey-800);
   --dark-theme-text: var(--col-sepia-300);
   --dark-theme-text-secondary: var(--col-sepia-450);
-  --dark-theme-code: var(--col-orange-400);
+  --dark-theme-code: var(--col-deep-saffron-400);
 }

--- a/styles/common.css
+++ b/styles/common.css
@@ -5,7 +5,11 @@
   --col-neutral-950: #151515;
   --col-neutral-900: #1e1e1e;
   --col-neutral-800: #2f2f2f;
-  --col-zinc-500: #7e818b;
+  --col-neutral-100: #f5f5f5;
+  --col-azure-900: #202431;
+  --col-azure-800: #292d3e;
+  --col-azure-600: #51597b;
+  --col-azure-500: #7e818b;
   --col-sepia-450: #b1a894;
   --col-sepia-400: #cac0a9;
   --col-sepia-300: #e3d8be;
@@ -15,8 +19,6 @@
   /* Colors */
   --col-magenta-800: #584355;
   --col-magenta-300: #ffaff3;
-  --col-azure-800: #292d3e;
-  --col-azure-600: #51597b;
   --col-cyan-200: #a6f0fc;
   --col-green-200: #c8ffa7;
   --col-yellow-300: #ffd596;
@@ -25,15 +27,22 @@
 
   /* Semantic colors */
   --brand-primary: var(--col-magenta-300);
+  --brand-success: var(--col-green-200);
+  --brand-warning: var(--col-yellow-300);
+  --brand-error: var(--col-red-400);
 
   /* Light theme */
   --light-theme-background: var(--col-sepia-050);
+  --light-theme-background-dim: var(--col-neutral-100);
   --light-theme-text: var(--col-black);
   --light-theme-text-secondary: var(--col-neutral-800);
+  --light-theme-code: var(--col-black);
 
   /* Dark theme */
   --dark-theme-background: var(--col-azure-800);
+  --dark-theme-background-dim: var(--col-azure-900);
   --dark-theme-background-alt: var(--col-neutral-800);
   --dark-theme-text: var(--col-sepia-300);
   --dark-theme-text-secondary: var(--col-sepia-450);
+  --dark-theme-code: var(--col-orange-400);
 }


### PR DESCRIPTION
## Context

All core gleam websites such as generated docs, packages site, etc. have their own independent CSS files, which makes them somewhat difficult to maintain while staying consistent with the styles of other sites.

While working on https://github.com/gleam-lang/packages/pull/28#issuecomment-1927964398, I suggested an idea to provide a shared collection of colors, sizes, etc. that will be reused across the websites for better consistency.
[We discussed this on discord](https://discord.com/channels/768594524158427167/768594524158427170/1205469801502220328) and chose to use the branding repo as the "source of truth", and to copy-and-paste the file around 


## Process

I decided it will be best/easiest to start with colors.
I downloaded the stylesheets from https://gleam.run/, https://packages.gleam.run/, https://tour.gleam.run/ and https://hexdocs.pm/gleam_stdlib/
Then I wrote a small python stript to find the most common colors between them.

To avoid bikeshedding color names, ~I'm using the names from https://www.color-name.com/, except for `faff-pink` because it's already being called this way in the community.~

update: It was suggested to use basic hue names and colors (similar to what Tailwind does). I assigned the intensity numbers by comparing the colors to the ones at https://tailwindcss.com/docs/background-color

I will be extending this stylesheet as I update the projects to use it

- [x] packages (+ new dark theme), PR https://github.com/gleam-lang/packages/pull/28
- [x] tour (+ new dark theme), PR https://github.com/gleam-lang/language-tour/pull/26
- [ ] docs site template
- [ ] official website
